### PR TITLE
fix: use correct outputs from rel_number step

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ To use this workflow, ensure you have:
 - The workflow uses base64 encoding for secure credential handling
 - Mock files are used to prevent exposure of sensitive configuration
 
+## Permissions
+```yaml
+permissions:
+  contents: write
+```
+
 ## Example Usage
 
 ```yaml

--- a/action.yaml
+++ b/action.yaml
@@ -145,13 +145,13 @@ runs:
         KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
         KEYSTORE_ALIAS: ${{ inputs.key_alias }}
         KEYSTORE_ALIAS_PASSWORD: ${{ inputs.key_password }}
-        VERSION_CODE: ${{ rel_number.outputs.version_code }}
-        VERSION: ${{ rel_number.outputs.version }}
+        VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
+        VERSION: ${{ steps.rel_number.outputs.version }}
       run: ./gradlew :${{ inputs.android_package_name }}:assembleRelease
 
     # Deploy to Firebase App Distribution
     - name: ☁️ Deploy to Firebase
       shell: bash
       env:
-        VERSION_CODE: ${{ rel_number.outputs.version_code }}
+        VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
       run: bundle exec fastlane android deploy_on_firebase


### PR DESCRIPTION
This commit fixes the workflow by using the correct output names from the `rel_number` step. It also adds necessary permissions for the workflow to write to the repository.

Specifically, the following changes were made:

- Updated `action.yaml` to use `steps.rel_number.outputs.version-code` and `steps.rel_number.outputs.version` instead of `rel_number.outputs.version_code` and `rel_number.outputs.version` respectively.
- Added `permissions` block to the `README.md` to grant write access to the repository contents.