### PR TITLE
chore: upgrade setup-java action to v4.2.2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ runs:
   using: composite
   steps:
     - name: Set up Java development environment
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4.2.2
       with:
         distribution: 'zulu'  # Use Zulu distribution of OpenJDK
         java-version: '17'     # Use Java 17 version


### PR DESCRIPTION
This commit updates the `setup-java` action from v2 to v4.2.2, ensuring the usage of the latest features and security improvements of the action.