### PR TITLE
fix: write changelogs to correct path

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,16 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
 
+    # Cache Gradle dependencies to speed up builds
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+          ~/.konan
+          build
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+
     # Setup Ruby for Fastlane automation
     - name: Configure Ruby
       uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
@@ -76,46 +86,6 @@ runs:
         echo "version-code=$VC" >> $GITHUB_OUTPUT
         VERSION=`cat version.txt`
         echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-
-    - name: Generate Release Notes
-      uses: actions/github-script@v7
-      id: release-notes
-      with:
-        github-token: ${{ inputs.github_token }}
-        script: |
-          try {
-            // Get latest release tag
-            const latestRelease = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const previousTag = latestRelease.data.tag_name;
-          
-            // Generate release notes
-            const params = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: '${{ steps.rel_number.outputs.version }}',
-              target_commitish: '${{ inputs.target_branch }}'
-            };
-          
-            const { data } = await github.rest.repos.generateReleaseNotes(params);
-            const changelog = data.body.replaceAll('`', '\'').replaceAll('"', '\'');
-          
-            // Write changelog files
-            const fs = require('fs');
-            fs.writeFileSync('changelogGithub', changelog);
-          
-            // Generate beta changelog
-            const { execSync } = require('child_process');
-            execSync('git log --format="* %s" HEAD^..HEAD > changelogBeta');
-          
-            return changelog;
-          } catch (error) {
-            console.error('Error generating release notes:', error);
-            return '';
-          }
 
     - name: Inflate Secrets
       shell: bash
@@ -148,6 +118,45 @@ runs:
         VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
         VERSION: ${{ steps.rel_number.outputs.version }}
       run: ./gradlew :${{ inputs.android_package_name }}:assembleRelease
+
+    - name: Generate Release Notes
+      uses: actions/github-script@v7
+      id: release-notes
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          try {
+            // Get latest release tag
+            const latestRelease = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const previousTag = latestRelease.data.tag_name;
+
+            // Generate release notes
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ steps.rel_number.outputs.version }}',
+              target_commitish: '${{ inputs.target_branch }}'
+            };
+
+            const { data } = await github.rest.repos.generateReleaseNotes(params);
+            const changelog = data.body.replaceAll('`', '\'').replaceAll('"', '\'');
+
+            // Write changelog files
+            const fs = require('fs');
+            fs.writeFileSync('${{ inputs.android_package_name }}/build/outputs/changelogGithub', changelog);
+
+            // Generate beta changelog
+            const { execSync } = require('child_process');
+            execSync('git log --format="* %s" HEAD^..HEAD > ${{ inputs.android_package_name }}/build/outputs/changelogBeta');
+
+            return changelog;
+          } catch (error) {
+            console.error('Error generating release notes:', error);
+            return '';
+          }
 
     # Deploy to Firebase App Distribution
     - name: ☁️ Deploy to Firebase


### PR DESCRIPTION
This commit fixes the workflow by writing the generated changelog files to the correct path within the build outputs directory.

Specifically, the following changes were made:

- Updated the path for writing the `changelogGithub` file to `${{ inputs.android_package_name }}/build/outputs/changelogGithub`.
- Updated the path for writing the `changelogBeta` file to `${{ inputs.android_package_name }}/build/outputs/changelogBeta`.