### PR TITLE
chore: use base64 encoded service account and google services files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The workflow requires the following inputs:
 - `key_password`: Password for the key alias (Required)
 
 ### Firebase and Google Services
-- `google_services`: Google services JSON file (Required)
-- `firebase_creds`: Firebase credentials JSON file (Required)
+- `google_services`: Base64 encoded Google services JSON file (Required)
+- `firebase_creds`: Base64 encoded Firebase credentials JSON file (Required)
 
 ### GitHub Configuration
 - `github_token`: GitHub token for repository interactions (Required)

--- a/action.yaml
+++ b/action.yaml
@@ -101,12 +101,11 @@ runs:
         echo $KEYSTORE | base64 --decode > ${{ inputs.android_package_name }}/release_keystore.keystore
         
         # Inflate google-services.json
-        echo $GOOGLE_SERVICES > ${{ inputs.android_package_name }}/google-services.json
+        echo $GOOGLE_SERVICES | base64 --decode > ${{ inputs.android_package_name }}/google-services.json
 
         # Inflate Firebase credentials
         touch ${{ inputs.android_package_name }}/firebaseAppDistributionServiceCredentialsFile.json
-        echo $FIREBASE_CREDS > ${{ inputs.android_package_name }}/firebaseAppDistributionServiceCredentialsFile.json
-    
+        echo $FIREBASE_CREDS | base64 --decode > ${{ inputs.android_package_name }}/firebaseAppDistributionServiceCredentialsFile.json
 
     # Build Android app
     - name: Build Android App


### PR DESCRIPTION
This commit updates the action to use base64 encoded Google services and Firebase credentials files instead of plain text.

Specifically, the following changes were made:

- The `google_services` and `firebase_creds` inputs now expect base64 encoded JSON files.
- The action decodes these files before using them.
- The README has been updated to reflect this change.