### PR TITLE
feat: integrate fastlane for publishing to firebase app distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,122 @@
-# Firebase App Distribution Action Using Fastlane
+# KMP Android App Publish Action
 
-## Overview
-
-This GitHub Actions workflow automates the process of building and deploying an Android application to Firebase App Distribution. It handles version generation, release notes creation, secret inflation, app building, and deployment.
-
-## Workflow Inputs
-
-The workflow requires the following inputs:
-
-### Project Configuration
-- `android_package_name`: Name of the Android project module (Required)
-
-### Signing Credentials
-- `keystore_file`: Base64 encoded keystore file (Required)
-- `keystore_password`: Password for the keystore file (Required)
-- `key_alias`: Key alias for the keystore file (Required)
-- `key_password`: Password for the key alias (Required)
-
-### Firebase and Google Services
-- `google_services`: Base64 encoded Google services JSON file (Required)
-- `firebase_creds`: Base64 encoded Firebase credentials JSON file (Required)
-
-### GitHub Configuration
-- `github_token`: GitHub token for repository interactions (Required)
-- `target_branch`: Target branch for deployment (Required)
-
-## Workflow Steps
-
-### 1. Environment Setup
-- Sets up Java 17 development environment using Zulu OpenJDK distribution
-- Configures Gradle build system
-- Installs Ruby and Fastlane with Firebase App Distribution plugin
-
-### 2. Version Generation
-- Generates a unique version number based on commit count and existing tags
-- Creates version files for tracking
-
-### 3. Release Notes Generation
-- Retrieves the latest release tag
-- Generates release notes using GitHub's release notes API
-- Creates changelog files for GitHub and beta releases
-
-### 4. Secret Inflation
-- Decodes and sets up required credentials:
-    - Creates mock debug google-services.json
-    - Inflates keystore file
-    - Inflates Google services JSON
-    - Inflates Firebase credentials
-
-### 5. Android App Build
-- Builds the Android app in release configuration
-- Uses provided keystore and signing credentials
-- Applies generated version number
-
-### 6. Firebase Deployment
-- Deploys the built app to Firebase App Distribution using Fastlane
+This GitHub Action automates the process of building and deploying Android applications to Firebase App Distribution using Fastlane.
 
 ## Prerequisites
 
-To use this workflow, ensure you have:
-- A GitHub repository with an Android project
-- Firebase App Distribution setup
-- Required credentials and tokens
-- Fastlane and Ruby installed in your development environment
+Before using this action, make sure you have:
 
-## Security Considerations
-- Use GitHub Secrets to manage sensitive information like tokens and credentials
-- The workflow uses base64 encoding for secure credential handling
-- Mock files are used to prevent exposure of sensitive configuration
+1. A valid Firebase project set up with App Distribution enabled
+2. Google Services JSON file for your Android project
+3. Firebase Service Account credentials JSON file
+4. Release keystore file for signing your Android app
 
-## Permissions
-```yaml
-permissions:
-  contents: write
+## Setup
+
+### Fastlane Setup
+
+Create a `Gemfile` in your project root with the following content:
+
+```ruby
+source "https://rubygems.org"
+
+gem "fastlane"
+gem "firebase_app_distribution"
 ```
 
-## Example Usage
+Create a `fastlane/Fastfile` with the following content:
+
+```ruby
+default_platform(:android)
+
+platform :android do
+  desc "Assemble Release APKs"
+  lane :assembleReleaseApks do |options|
+    gradle(
+      task: "assemble",
+      build_type: "Release",
+      properties: {
+        "android.injected.signing.store.file" => options[:storeFile],
+        "android.injected.signing.store.password" => options[:storePassword],
+        "android.injected.signing.key.alias" => options[:keyAlias],
+        "android.injected.signing.key.password" => options[:keyPassword],
+      }
+    )
+  end
+
+  desc "Publish Release Play Store artifacts to Firebase App Distribution"
+  lane :deploy_on_firebase do |options|
+    firebase_app_distribution(
+      app: "1:2362782:android:f6283929302", # Your Firebase App ID
+      android_artifact_type: "APK",
+      android_artifact_path: options[:apkFile],
+      service_credentials_file: options[:serviceCredsFile],
+      groups: options[:groups],
+      release_notes: "Your Release Notes",
+    )
+  end
+end
+```
+
+## Usage
+
+Add the following workflow to your GitHub Actions:
 
 ```yaml
-- uses: openMF/KMP-android-firebase-publish-action@v1.0.0
-  with:
-    android_package_name: 'app'
-    keystore_file: ${{ secrets.KEYSTORE_FILE }}
-    keystore_password: ${{ secrets.KEYSTORE_PASSWORD }}
-    key_alias: 'release'
-    key_password: ${{ secrets.KEY_PASSWORD }}
-    google_services: ${{ secrets.GOOGLE_SERVICES_JSON }}
-    firebase_creds: ${{ secrets.FIREBASE_CREDENTIALS }}
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    target_branch: 'main'
+name: Deploy to Firebase
+
+on:
+  push:
+    branches: [ main ]
+  # Or trigger on release
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Deploy to Firebase
+        uses: openMF/kmp-android-firebase-publish-action@v2.0.0
+        with:
+          android_package_name: 'app'  # Your Android module name
+          google_services: ${{ secrets.GOOGLE_SERVICES }}
+          firebase_creds: ${{ secrets.FIREBASE_CREDS }}
+          keystore_file: ${{ secrets.RELEASE_KEYSTORE }}
+          keystore_password: ${{ secrets.KEYSTORE_PASSWORD }}
+          keystore_alias: ${{ secrets.KEYSTORE_ALIAS }}
+          keystore_alias_password: ${{ secrets.KEYSTORE_ALIAS_PASSWORD }}
+          tester_groups: 'qa-team,beta-testers'
 ```
+
+## Inputs
+
+| Input                     | Description                                       | Required |
+|---------------------------|---------------------------------------------------|----------|
+| `android_package_name`    | Name of your Android project module (e.g., 'app') | Yes      |
+| `keystore_file`           | Base64 encoded release keystore file              | Yes      |
+| `keystore_password`       | Password for the keystore file                    | Yes      |
+| `keystore_alias`          | Alias for the keystore file                       | Yes      |
+| `keystore_alias_password` | Password for the keystore alias                   | Yes      |
+| `google_services`         | Base64 encoded Google services JSON file          | Yes      |
+| `firebase_creds`          | Base64 encoded Firebase credentials JSON file     | Yes      |
+| `tester_groups`           | Comma-separated list of Firebase tester groups    | Yes      |
+
+## Setting up Secrets
+
+1. Encode your files to base64:
+```bash
+base64 -i path/to/release.keystore -o keystore.txt
+base64 -i path/to/google-services.json -o google-services.txt
+base64 -i path/to/firebase-credentials.json -o firebase-creds.txt
+```
+
+2. Add the following secrets to your GitHub repository:
+- `GOOGLE_SERVICES`: Content of google-services.txt
+- `FIREBASE_CREDS`: Content of firebase-creds.txt
+- `RELEASE_KEYSTORE`: Content of keystore.txt
+- `KEYSTORE_PASSWORD`: Your keystore password
+- `KEYSTORE_ALIAS`: Your keystore alias
+- `KEYSTORE_ALIAS_PASSWORD`: Your keystore alias password

--- a/action.yaml
+++ b/action.yaml
@@ -9,21 +9,19 @@ inputs:
   android_package_name:
     description: 'Name of the Android project module'
     required: true
-  release_type:
-    description: 'Play Store Release Type'
 
   keystore_file:
     description: 'Base64 encoded keystore file'
-    required: true
+    required: false
   keystore_password:
     description: 'Password for the keystore file'
-    required: true
-  key_alias:
-    description: 'Key alias for the keystore file'
-    required: true
-  key_password:
-    description: 'Password for the key alias'
-    required: true
+    required: false
+  keystore_alias:
+    description: 'Alias for the keystore file'
+    required: false
+  keystore_alias_password:
+    description: 'Password for the keystore alias'
+    required: false
 
   google_services:
     description: 'Google services JSON file'
@@ -31,37 +29,14 @@ inputs:
   firebase_creds:
     description: 'Firebase credentials JSON file'
     required: true
-  github_token:
-    description: 'GitHub token'
-    required: true
-  target_branch:
-    description: 'Target branch for deployment'
+
+  tester_groups:
+    description: 'Firebase Tester Group'
     required: true
 
 runs:
   using: composite
   steps:
-    - name: Set up Java development environment
-      uses: actions/setup-java@v4.2.2
-      with:
-        distribution: 'zulu'  # Use Zulu distribution of OpenJDK
-        java-version: '17'     # Use Java 17 version
-
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-
-    # Cache Gradle dependencies and build outputs to speed up future builds
-    - name: Cache Gradle and build outputs
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-          ~/.konan
-          build
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: ${{ runner.os }}-gradle-
-
     # Setup Ruby for Fastlane automation
     - name: Configure Ruby
       uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
@@ -77,90 +52,41 @@ runs:
         bundle exec fastlane add_plugin firebase_app_distribution
         bundle exec fastlane add_plugin increment_build_number
 
-    # Generate version number
-    - name: Generate Release Number
-      id: rel_number
-      shell: bash
-      run: |
-        ./gradlew versionFile
-        COMMITS=`git rev-list --count HEAD`
-        TAGS=`git tag | grep -v beta | wc -l`
-        VC=$(((COMMITS+TAGS) << 1))
-        echo "version-code=$VC" >> $GITHUB_OUTPUT
-        VERSION=`cat version.txt`
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-
     - name: Inflate Secrets
       shell: bash
       env:
-        KEYSTORE: ${{ inputs.keystore_file }}
         GOOGLE_SERVICES: ${{ inputs.google_services }}
         FIREBASE_CREDS: ${{ inputs.firebase_creds }}
+        KEYSTORE: ${{ inputs.keystore_file }}
       run: |
+        mkdir -p secrets
+        
+        # Inflate google-services.json
+        echo $GOOGLE_SERVICES | base64 --decode > ${{ inputs.android_package_name }}/google-services.json
+        
+        # Inflate keystore
+        echo $KEYSTORE | base64 --decode > keystores/release_keystore.keystore
+        
         # Inflate Firebase credentials
-        touch ${{ inputs.android_package_name }}/firebaseAppDistributionServiceCredentialsFile.json
-        echo $FIREBASE_CREDS | base64 --decode > ${{ inputs.android_package_name }}/firebaseAppDistributionServiceCredentialsFile.json
+        touch secrets/firebaseAppDistributionServiceCredentialsFile.json
+        echo $FIREBASE_CREDS | base64 --decode > secrets/firebaseAppDistributionServiceCredentialsFile.json
 
-    # Build Android app
-    - name: Build Android App
+    - name: Build Release Android App
       shell: bash
       env:
         KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
-        KEYSTORE_ALIAS: ${{ inputs.key_alias }}
-        KEYSTORE_ALIAS_PASSWORD: ${{ inputs.key_password }}
-        VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
-        VERSION: ${{ steps.rel_number.outputs.version }}
-      run: ./gradlew :${{ inputs.android_package_name }}:assembleRelease
+        KEYSTORE_ALIAS: ${{ inputs.keystore_alias }}
+        KEYSTORE_ALIAS_PASSWORD: ${{ inputs.keystore_alias_password }}
+      run: |
+        bundle exec fastlane android assembleReleaseApks \
+        storeFile:release_keystore.keystore \
+        storePassword:${{ env.KEYSTORE_PASSWORD }} \
+        keyAlias:${{ env.KEYSTORE_ALIAS }} \
+        keyPassword:${{ env.KEYSTORE_ALIAS_PASSWORD }}
 
-    - name: Upload APK as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: android-app
-        path: |
-          **/build/outputs/apk/demo/**/*.apk
-          **/build/outputs/apk/prod/**/*.apk
-
-    - name: Generate Release Notes
-      uses: actions/github-script@v7
-      id: release-notes
-      with:
-        github-token: ${{ inputs.github_token }}
-        script: |
-          try {
-            // Get latest release tag
-            const latestRelease = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const previousTag = latestRelease.data.tag_name;
-
-            // Generate release notes
-            const params = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: '${{ steps.rel_number.outputs.version }}',
-              target_commitish: '${{ inputs.target_branch }}'
-            };
-
-            const { data } = await github.rest.repos.generateReleaseNotes(params);
-            const changelog = data.body.replaceAll('`', '\'').replaceAll('"', '\'');
-
-            // Write changelog files
-            const fs = require('fs');
-            fs.writeFileSync('${{ inputs.android_package_name }}/build/outputs/changelogGithub', changelog);
-
-            // Generate beta changelog
-            const { execSync } = require('child_process');
-            execSync('git log --format="* %s" HEAD^..HEAD > ${{ inputs.android_package_name }}/build/outputs/changelogBeta');
-
-            return changelog;
-          } catch (error) {
-            console.error('Error generating release notes:', error);
-            return '';
-          }
     # Deploy to Firebase App Distribution
     - name: ☁️ Deploy to Firebase
       shell: bash
-      env:
-        VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
-      run: bundle exec fastlane android deploy_on_firebase
+      run: |
+        bundle exec fastlane android deploy_on_firebase \
+        groups:${{ inputs.tester_groups }}


### PR DESCRIPTION
This commit integrates Fastlane for publishing Android applications to Firebase App Distribution.

The following changes were made:

- Updated the workflow to use Fastlane for building and deploying the Android app.
- Added Fastlane configuration files (`Gemfile`, `Fastfile`).
- Updated the workflow inputs to include required parameters for Fastlane.
- Updated the workflow steps to:
    - Install Fastlane and the Firebase App Distribution plugin.
    - Inflate secrets (Google Services JSON, Firebase credentials, keystore).
    - Build the release Android app using Fastlane.
    - Deploy the app to Firebase App Distribution using Fastlane.
- Updated the README with instructions and usage details.