### PR TITLE
feat: add output to retrieve built APK files

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ jobs:
 | `firebase_creds`          | Base64 encoded Firebase credentials JSON file     | Yes      |
 | `tester_groups`           | Comma-separated list of Firebase tester groups    | Yes      |
 
+## Outputs
+`android-app` - The path to the generated APK files.
+
 ## Setting up Secrets
 
 1. Encode your files to base64:

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: KMP Android App Publish On Firebase & Playstore Beta/Internal
+name: KMP Android App Publish On Firebase
 description: 'Build and deploy Android app on Firebase App Distribution using fastlane'
 author: 'Mifos Initiative'
 branding:
@@ -90,3 +90,11 @@ runs:
       run: |
         bundle exec fastlane android deploy_on_firebase \
         groups:${{ inputs.tester_groups }}
+
+    - name: Upload APK as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: android-app
+        path: |
+          **/build/outputs/apk/demo/**/*.apk
+          **/build/outputs/apk/prod/**/*.apk


### PR DESCRIPTION
This pull request includes updates to the documentation and configuration for the KMP Android App Publish workflow, specifically focusing on Firebase deployment and artifact management.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R109): Added a new section for outputs, specifying that `android-app` is the path to the generated APK files.

Workflow configuration updates:

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL1-R1): Updated the action name to "KMP Android App Publish On Firebase" and modified the description to reflect the focus on Firebase App Distribution.
* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR93-R100): Added a new step to upload the generated APK files as artifacts using the `actions/upload-artifact@v4` action. This step includes specifying the paths to the APK files for both demo and production builds.