### PR TITLE
feat: Support for Multi Flavour Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ jobs:
         uses: openMF/kmp-android-firebase-publish-action@v2.0.0
         with:
           android_package_name: 'app'  # Your Android module name
+          release_type: 'prod'  # Release type (prod/demo)
           google_services: ${{ secrets.GOOGLE_SERVICES }}
           firebase_creds: ${{ secrets.FIREBASE_CREDS }}
           keystore_file: ${{ secrets.RELEASE_KEYSTORE }}
@@ -111,7 +112,7 @@ jobs:
 | `tester_groups`           | Comma-separated list of Firebase tester groups    | Yes      |
 
 ## Outputs
-`android-app` - The path to the generated APK files.
+`firebase-app` - The path to the generated APK files.
 
 ## Setting up Secrets
 

--- a/README.md
+++ b/README.md
@@ -30,29 +30,34 @@ Create a `fastlane/Fastfile` with the following content:
 default_platform(:android)
 
 platform :android do
-  desc "Assemble Release APKs"
-  lane :assembleReleaseApks do |options|
-    gradle(
-      task: "assemble",
-      build_type: "Release",
-      properties: {
-        "android.injected.signing.store.file" => options[:storeFile],
-        "android.injected.signing.store.password" => options[:storePassword],
-        "android.injected.signing.key.alias" => options[:keyAlias],
-        "android.injected.signing.key.password" => options[:keyPassword],
-      }
+  desc "Publish Release Artifacts to Firebase App Distribution"
+  lane :deployReleaseApkOnFirebase do |options|
+    # Generate version
+    generateVersion = generateVersion(
+        platform: "firebase",
+        appId: options[:appId],
+        serviceCredsFile: options[:serviceCredsFile]
     )
-  end
 
-  desc "Publish Release Play Store artifacts to Firebase App Distribution"
-  lane :deploy_on_firebase do |options|
+    # Generate Release Note
+    releaseNotes = generateFullReleaseNote()
+
+    buildAndSignApp(
+      taskName: "assembleProd",
+      buildType: "Release",
+      storeFile: options[:storeFile],
+      storePassword: options[:storePassword],
+      keyAlias: options[:keyAlias],
+      keyPassword: options[:keyPassword],
+    )
+
     firebase_app_distribution(
-      app: "1:2362782:android:f6283929302", # Your Firebase App ID
+      app: options[:appId],
       android_artifact_type: "APK",
       android_artifact_path: options[:apkFile],
       service_credentials_file: options[:serviceCredsFile],
       groups: options[:groups],
-      release_notes: "Your Release Notes",
+      release_notes: "#{releaseNotes}",
     )
   end
 end
@@ -96,6 +101,7 @@ jobs:
 | Input                     | Description                                       | Required |
 |---------------------------|---------------------------------------------------|----------|
 | `android_package_name`    | Name of your Android project module (e.g., 'app') | Yes      |
+| `release_type`            | Type of Release eg. `prod` or `demo`              | No       |
 | `keystore_file`           | Base64 encoded release keystore file              | Yes      |
 | `keystore_password`       | Password for the keystore file                    | Yes      |
 | `keystore_alias`          | Alias for the keystore file                       | Yes      |

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
   android_package_name:
     description: 'Name of the Android project module'
     required: true
+  release_type:
+    description: 'Type of release to be deployed eg. demo, prod'
+    required: false
+    default: 'prod'
 
   keystore_file:
     description: 'Base64 encoded keystore file'
@@ -71,30 +75,49 @@ runs:
         touch secrets/firebaseAppDistributionServiceCredentialsFile.json
         echo $FIREBASE_CREDS | base64 --decode > secrets/firebaseAppDistributionServiceCredentialsFile.json
 
-    - name: Build Release Android App
+    # Deploy to Firebase App Distribution
+    - name: ☁️ Deploy Prod Application on Firebase
+      if: ${{ inputs.release_type == 'prod' }}
       shell: bash
       env:
         KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
         KEYSTORE_ALIAS: ${{ inputs.keystore_alias }}
         KEYSTORE_ALIAS_PASSWORD: ${{ inputs.keystore_alias_password }}
       run: |
-        bundle exec fastlane android assembleReleaseApks \
+        bundle exec fastlane android deployReleaseApkOnFirebase \
         storeFile:release_keystore.keystore \
         storePassword:${{ env.KEYSTORE_PASSWORD }} \
         keyAlias:${{ env.KEYSTORE_ALIAS }} \
         keyPassword:${{ env.KEYSTORE_ALIAS_PASSWORD }}
+        groups:${{ inputs.tester_groups }}
 
     # Deploy to Firebase App Distribution
-    - name: ☁️ Deploy to Firebase
+    - name: ☁️ Deploy Demo Application on Firebase
+      if: ${{ inputs.release_type == 'demo' }}
+      shell: bash
+      env:
+        KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
+        KEYSTORE_ALIAS: ${{ inputs.keystore_alias }}
+        KEYSTORE_ALIAS_PASSWORD: ${{ inputs.keystore_alias_password }}
+      run: |
+        bundle exec fastlane android deployDemoApkOnFirebase \
+        storeFile:release_keystore.keystore \
+        storePassword:${{ env.KEYSTORE_PASSWORD }} \
+        keyAlias:${{ env.KEYSTORE_ALIAS }} \
+        keyPassword:${{ env.KEYSTORE_ALIAS_PASSWORD }}
+        groups:${{ inputs.tester_groups }}
+     
+    # Clean up secrets
+    - name: Clean up secrets
       shell: bash
       run: |
-        bundle exec fastlane android deploy_on_firebase \
-        groups:${{ inputs.tester_groups }}
+        rm -rf secrets
+        rm -rf ${{ inputs.android_package_name }}/google-services.json
+        rm -rf keystores/release_keystore.keystore
 
     - name: Upload APK as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: android-app
+        name: firebase-app
         path: |
-          **/build/outputs/apk/demo/**/*.apk
-          **/build/outputs/apk/prod/**/*.apk
+          **/*.apk  


### PR DESCRIPTION
This commit enhances the workflow to publish Android release artifacts to Firebase App Distribution.

Specifically, the following changes were made:

- Added `release_type` input to specify the release type (prod or demo).
- Updated Fastfile to define lanes for building and deploying to Firebase App Distribution.
- Implemented logic to generate release notes and version.
- Modified action.yaml to trigger different deployment lanes based on `release_type`.
- Updated artifact upload to include APKs.